### PR TITLE
[Feat|DETS] : Preconfigured connector URL fixes and unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+### Fixed
 - Fixed veracode security CVE-2023-6378(logback-classic Denial Of Service)
 - Upgrade Spring Boot to get rid of CVE-2023-46589 and CVE-2023-34053
 - Fixed security issue for openssl
+- Fixed preconfigured connector URL '/' issue
+- Fixed dynamic asset name generation issue
+
+### Added
+- Added unit tests for Controller and service
 
 ## [1.0.9] - 2023-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
-NA
+
+## [1.0.10] - 2023-12-06
+
+### Changed
+ - Fixed security issue for openssl
 
 ## [1.0.9] - 2023-08-31
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /tmp
 
 RUN mvn clean install -Dmaven.test.skip=true
 
-FROM eclipse-temurin:17.0.8.1_1-jdk
+FROM eclipse-temurin:17.0.9_9-jdk-alpine
 
 ENV TEMP=/tmp
 COPY --from=build $TEMP/target/*.jar /app/app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #################################################################################
-# Copyright (c) 2022,2023 T-Systems International GmbH
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2023,2024 T-Systems International GmbH
+# Copyright (c) 2022,2023,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /tmp
 
 RUN mvn clean install -Dmaven.test.skip=true
 
-FROM eclipse-temurin:17.0.6_10-jdk-alpine
+FROM eclipse-temurin:17.0.8.1_1-jdk
 
 ENV TEMP=/tmp
 COPY --from=build $TEMP/target/*.jar /app/app.jar

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Store all above values in application properties file.
 Currently, authentication is not supported for this service
 
 ### EDC Version Supported
-- 0.4.1
+- 0.4.x
+- 0.5.x (Cross version testing is not supported between 0.4 and 0.5)
 
 # Container images
 

--- a/docs/ARC42.md
+++ b/docs/ARC42.md
@@ -27,7 +27,7 @@ testing of the connector as a Consumer and Provider.
 ### Non-functional requirements
 
 *   The E2E-DETS will have to be: accessible, easy to use, secure, efficient etc.
-*   The E2E-DETS will only support EDC Version 0.4.1
+*   The E2E-DETS will only support EDC Version 0.4 and EDC Version 0.5 (Cross version testing is not supported between 0.4 and 0.5)
 
 ### Quality Goals
 

--- a/src/main/java/org/connector/e2etestservice/controller/E2eTestController.java
+++ b/src/main/java/org/connector/e2etestservice/controller/E2eTestController.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 T-Systems International GmbH
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 T-Systems International GmbH
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main/java/org/connector/e2etestservice/controller/E2eTestController.java
+++ b/src/main/java/org/connector/e2etestservice/controller/E2eTestController.java
@@ -58,7 +58,7 @@ public class E2eTestController {
 			@Value("${default.edc.apiKeyHeader}") String testConnectorApiKeyHeader,
 			@Value("${default.edc.apiKey}") String testConnectorApiKey) {
 		this.testConnectorService = testConnectorService;
-		this.testConnectorUrl = testConnectorUrl;
+		this.testConnectorUrl = Utils.removeLastSlashFromURL(testConnectorUrl);
 		this.testConnectorApiKeyHeader = testConnectorApiKeyHeader;
 		this.testConnectorApiKey = testConnectorApiKey;
 	}

--- a/src/main/java/org/connector/e2etestservice/controller/UIController.java
+++ b/src/main/java/org/connector/e2etestservice/controller/UIController.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 T-Systems International GmbH
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 T-Systems International GmbH
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main/java/org/connector/e2etestservice/controller/UIController.java
+++ b/src/main/java/org/connector/e2etestservice/controller/UIController.java
@@ -20,16 +20,10 @@
 
 package org.connector.e2etestservice.controller;
 
-import jakarta.validation.constraints.NotBlank;
-import org.connector.e2etestservice.Utils;
-import org.connector.e2etestservice.model.ConnectorTestRequest;
-import org.connector.e2etestservice.service.TestConnectorService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
@@ -41,16 +35,13 @@ public class UIController {
     private String testConnectorApiKeyHeader;
     private String testConnectorApiKey;
 
-    private TestConnectorService testConnectorService;
-
     @Autowired
     public UIController(@Value("${default.edc.hostname}") String testConnectorUrl,
                         @Value("${default.edc.apiKeyHeader}") String testConnectorApiKeyHeader,
-                        @Value("${default.edc.apiKey}") String testConnectorApiKey, TestConnectorService testConnectorService) {
+                        @Value("${default.edc.apiKey}") String testConnectorApiKey) {
         this.testConnectorUrl = testConnectorUrl;
         this.testConnectorApiKeyHeader = testConnectorApiKeyHeader;
         this.testConnectorApiKey = testConnectorApiKey;
-        this.testConnectorService = testConnectorService;
     }
 
 
@@ -60,41 +51,6 @@ public class UIController {
         model.setViewName("index");
         model.addObject("preconfiguredConnectorUrl",testConnectorUrl);
         model.addObject("connectorApiKeyHeader","X-Api-Key");
-        return model;
-    }
-
-    @PostMapping(value = "/testconnector")
-    public ModelAndView getIndexPageWithConnectorDetails(@NotBlank @RequestParam String connectorHost,
-                                                         @NotBlank @RequestParam String apiKeyHeader,
-                                                         @NotBlank @RequestParam String apiKeyValue) {
-
-        ConnectorTestRequest connectorTestRequest = ConnectorTestRequest.builder()
-                .connectorHost(connectorHost)
-                .apiKeyHeader(apiKeyHeader)
-                .apiKeyValue(apiKeyValue)
-                .build();
-        ModelAndView model = new ModelAndView();
-        model.setViewName("index");
-
-        connectorTestRequest.setConnectorHost(Utils.removeLastSlashFromURL(connectorTestRequest.getConnectorHost()));
-
-        ConnectorTestRequest preconfiguredTestConnector = ConnectorTestRequest.builder()
-                .connectorHost(testConnectorUrl)
-                .apiKeyHeader(testConnectorApiKeyHeader).apiKeyValue(testConnectorApiKey).build();
-        boolean consumerTestResult = testConnectorService.testConnectorConnectivity(connectorTestRequest,
-                preconfiguredTestConnector);
-        boolean providerTestResult = testConnectorService.testConnectorConnectivity(preconfiguredTestConnector,
-                connectorTestRequest);
-        if (consumerTestResult && providerTestResult) {
-            model.addObject(RESULT, "Connector is working as a consumer and provider");
-        } else {
-            model.addObject(RESULT, "Connector is not working properly");
-        }
-
-        model.addObject("preconfiguredConnectorUrl",testConnectorUrl);
-        model.addObject("connectorUrl",connectorTestRequest.getConnectorHost());
-        model.addObject("connectorApiKeyHeader",connectorTestRequest.getApiKeyHeader());
-        model.addObject("connectorApiKey",connectorTestRequest.getApiKeyValue());
         return model;
     }
 }

--- a/src/main/java/org/connector/e2etestservice/model/EdcTemplateFactory.java
+++ b/src/main/java/org/connector/e2etestservice/model/EdcTemplateFactory.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 T-Systems International GmbH
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 T-Systems International GmbH
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main/java/org/connector/e2etestservice/model/EdcTemplateFactory.java
+++ b/src/main/java/org/connector/e2etestservice/model/EdcTemplateFactory.java
@@ -42,10 +42,10 @@ public class EdcTemplateFactory {
     }
 
     @SneakyThrows
-    public ObjectNode generateCatalogRequestObject(String templatePath,
-                                                   String providerProtocolUrl) {
+    public ObjectNode generateDynamicDummyEdcRequestObject(String templatePath,
+                                                   String dynamicVariable) {
         String readValueAsTree = getSchemaFromFile(templatePath);
-        String jsonString = String.format(readValueAsTree, providerProtocolUrl);
+        String jsonString = String.format(readValueAsTree, dynamicVariable);
         return (ObjectNode) new ObjectMapper().readTree(jsonString);
     }
 

--- a/src/main/java/org/connector/e2etestservice/model/EdcTemplateFactory.java
+++ b/src/main/java/org/connector/e2etestservice/model/EdcTemplateFactory.java
@@ -43,9 +43,9 @@ public class EdcTemplateFactory {
 
     @SneakyThrows
     public ObjectNode generateDynamicDummyEdcRequestObject(String templatePath,
-                                                   String dynamicVariable) {
+                                                           String[] dynamicVariable) {
         String readValueAsTree = getSchemaFromFile(templatePath);
-        String jsonString = String.format(readValueAsTree, dynamicVariable);
+        String jsonString = String.format(readValueAsTree, (Object[])dynamicVariable);
         return (ObjectNode) new ObjectMapper().readTree(jsonString);
     }
 

--- a/src/main/java/org/connector/e2etestservice/service/DataOfferService.java
+++ b/src/main/java/org/connector/e2etestservice/service/DataOfferService.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 T-Systems International GmbH
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 T-Systems International GmbH
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main/java/org/connector/e2etestservice/service/DataOfferService.java
+++ b/src/main/java/org/connector/e2etestservice/service/DataOfferService.java
@@ -25,6 +25,7 @@ import org.connector.e2etestservice.facilitator.ConnectorFacilitator;
 import org.connector.e2etestservice.model.ConnectorTestRequest;
 import org.connector.e2etestservice.model.EdcTemplateFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -34,11 +35,15 @@ import lombok.extern.slf4j.Slf4j;
 public class DataOfferService {
 	private EdcTemplateFactory edcTemplateFactory;
 	private ConnectorFacilitator connectorFacilitator;
+	private String sampleAssetName;
 
 	@Autowired
-	public DataOfferService(EdcTemplateFactory edcTemplateFactory, ConnectorFacilitator connectorFacilitator) {
+	public DataOfferService(EdcTemplateFactory edcTemplateFactory,
+							ConnectorFacilitator connectorFacilitator,
+							@Value("${sample.asset.name}") String sampleAssetName) {
 		this.edcTemplateFactory = edcTemplateFactory;
 		this.connectorFacilitator = connectorFacilitator;
+		this.sampleAssetName = sampleAssetName;
 	}
 
 	public void createDataOfferForTesting(ConnectorTestRequest companyConnectorRequest) {
@@ -46,7 +51,7 @@ public class DataOfferService {
 			// 1. check if already present and then Create Asset
 			if (!connectorFacilitator.isTestAssetPresent(companyConnectorRequest)) {
 				ObjectNode assetEntryRequest = edcTemplateFactory.
-						generateDummyEdcRequestObject("/edc-request-template/sample-asset.json");
+						generateDynamicDummyEdcRequestObject("/edc-request-template/sample-asset.json", sampleAssetName);
 				connectorFacilitator.createAsset(companyConnectorRequest, assetEntryRequest);
 			}
 
@@ -72,7 +77,7 @@ public class DataOfferService {
 
 	public ObjectNode getCatalogRequestBody(String providerProtocolUrl) {
 		return edcTemplateFactory.
-				generateCatalogRequestObject(
+				generateDynamicDummyEdcRequestObject(
 						"/edc-request-template/sample-catalog.json", providerProtocolUrl);
 	}
 }

--- a/src/main/java/org/connector/e2etestservice/service/DataOfferService.java
+++ b/src/main/java/org/connector/e2etestservice/service/DataOfferService.java
@@ -37,13 +37,17 @@ public class DataOfferService {
 	private ConnectorFacilitator connectorFacilitator;
 	private String sampleAssetName;
 
+	private String sampleAssetType;
+
 	@Autowired
 	public DataOfferService(EdcTemplateFactory edcTemplateFactory,
 							ConnectorFacilitator connectorFacilitator,
-							@Value("${sample.asset.name}") String sampleAssetName) {
+							@Value("${sample.asset.name}") String sampleAssetName,
+							@Value("${sample.asset.type}") String sampleAssetType) {
 		this.edcTemplateFactory = edcTemplateFactory;
 		this.connectorFacilitator = connectorFacilitator;
 		this.sampleAssetName = sampleAssetName;
+		this.sampleAssetType = sampleAssetType;
 	}
 
 	public void createDataOfferForTesting(ConnectorTestRequest companyConnectorRequest) {
@@ -51,7 +55,7 @@ public class DataOfferService {
 			// 1. check if already present and then Create Asset
 			if (!connectorFacilitator.isTestAssetPresent(companyConnectorRequest)) {
 				ObjectNode assetEntryRequest = edcTemplateFactory.
-						generateDynamicDummyEdcRequestObject("/edc-request-template/sample-asset.json", sampleAssetName);
+						generateDynamicDummyEdcRequestObject("/edc-request-template/sample-asset.json", new String[]{sampleAssetName, sampleAssetType});
 				connectorFacilitator.createAsset(companyConnectorRequest, assetEntryRequest);
 			}
 
@@ -78,6 +82,6 @@ public class DataOfferService {
 	public ObjectNode getCatalogRequestBody(String providerProtocolUrl) {
 		return edcTemplateFactory.
 				generateDynamicDummyEdcRequestObject(
-						"/edc-request-template/sample-catalog.json", providerProtocolUrl);
+						"/edc-request-template/sample-catalog.json", new String[]{providerProtocolUrl});
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,8 @@
 #default.edc.apiKeyHeader=${edcapikeyheader}
 #default.edc.apiKey=${edcapikey}
 
+# Sample Asset Name
+sample.asset.name=Welcome to Catena
+
 ## EDC API path
 edc.ids.path=/api/v1/ids/data

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 #################################################################################
-# Copyright (c) 2023 T-Systems International GmbH
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023,2024 T-Systems International GmbH
+# Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@
 #default.edc.apiKey=${edcapikey}
 
 # Sample Asset Name
-sample.asset.name=Welcome to Catena
+sample.asset.name=Welcome to Catena-X
 
 ## EDC API path
 edc.ids.path=/api/v1/ids/data

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,7 @@
 
 # Sample Asset Name
 sample.asset.name=Welcome to Catena-X
+sample.asset.type=data.core.sample
 
 ## EDC API path
 edc.ids.path=/api/v1/ids/data

--- a/src/main/resources/edc-request-template/sample-asset.json
+++ b/src/main/resources/edc-request-template/sample-asset.json
@@ -5,10 +5,10 @@
 		"@id": "sample",
 		"properties": {
 			"id": "sample",
-			"name": "Welcome to Catena-X",
+			"name": "%s",
 			"contenttype": "application/json",
 			"policy-id": "use-eu",
-			"type": "data.core.digitalTwin.submodel"
+			"type": "data.core.sample"
 		}
 	},
 	"dataAddress": {

--- a/src/main/resources/edc-request-template/sample-asset.json
+++ b/src/main/resources/edc-request-template/sample-asset.json
@@ -8,7 +8,7 @@
 			"name": "%s",
 			"contenttype": "application/json",
 			"policy-id": "use-eu",
-			"type": "data.core.sample"
+			"type": "%s"
 		}
 	},
 	"dataAddress": {

--- a/src/test/java/org/connector/e2etestservice/controller/E2eTestControllerTest.java
+++ b/src/test/java/org/connector/e2etestservice/controller/E2eTestControllerTest.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 T-Systems International GmbH
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 T-Systems International GmbH
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/test/java/org/connector/e2etestservice/controller/E2eTestControllerTest.java
+++ b/src/test/java/org/connector/e2etestservice/controller/E2eTestControllerTest.java
@@ -1,0 +1,138 @@
+/********************************************************************************
+ * Copyright (c) 2023 T-Systems International GmbH
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.connector.e2etestservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.connector.e2etestservice.model.ConnectorTestRequest;
+import org.connector.e2etestservice.model.OwnConnectorTestRequest;
+import org.connector.e2etestservice.service.TestConnectorService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+public class E2eTestControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private TestConnectorService mockTestConnectorService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @SneakyThrows
+    @Test
+    void testConnectorMethod_WithValidDto() {
+        Mockito.when(mockTestConnectorService.testConnectorConnectivity(any(), any()))
+                        .thenReturn(true);
+
+        mvc.perform(MockMvcRequestBuilders
+                .post("/connector-test")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(getValidConnectorTestRequest()))
+        ).andExpect(status().isOk());
+
+    }
+
+    @SneakyThrows
+    @Test
+    void testConnectorMethod_WithInvalidDto() {
+        Mockito.when(mockTestConnectorService.testConnectorConnectivity(any(), any()))
+                .thenReturn(true);
+
+        mvc.perform(MockMvcRequestBuilders
+                .post("/connector-test")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(getInvalidConnectorTestRequest()))
+        ).andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+
+    }
+
+    @SneakyThrows
+    @Test
+    void testOwnConnectorMethod_WithValidDto() {
+        Mockito.when(mockTestConnectorService.testConnectorConnectivity(any(), any()))
+                .thenReturn(true);
+
+        mvc.perform(MockMvcRequestBuilders
+                .post("/own-connector-test")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(getValidOwnConnectorTestRequest()))
+        ).andExpect(status().isOk());
+
+    }
+
+    @SneakyThrows
+    @Test
+    void testOwnConnectorMethod_WithInvalidDto() {
+        Mockito.when(mockTestConnectorService.testConnectorConnectivity(any(), any()))
+                .thenReturn(true);
+
+        mvc.perform(MockMvcRequestBuilders
+                .post("/connector-test")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(getInvalidOwnConnectorTestRequest()))
+        ).andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+
+    }
+
+    private ConnectorTestRequest getValidConnectorTestRequest() {
+        return ConnectorTestRequest.builder()
+                .apiKeyValue("api_key")
+                .apiKeyHeader("api_key_header")
+                .connectorHost("https://connector_host.com")
+                .build();
+    }
+
+    private ConnectorTestRequest getInvalidConnectorTestRequest() {
+        return ConnectorTestRequest.builder()
+                .build();
+    }
+
+    private OwnConnectorTestRequest getValidOwnConnectorTestRequest() {
+        return OwnConnectorTestRequest.builder()
+                .firstConnectorHost("https://connector_host.com")
+                .firstApiKeyHeader("api_key_header")
+                .firstApiKeyValue("api_key")
+                .secondConnectorHost("https://connector_host.com")
+                .secondApiKeyHeader("api_key_header")
+                .secondApiKeyValue("api_key")
+                .build();
+    }
+
+    private OwnConnectorTestRequest getInvalidOwnConnectorTestRequest() {
+        return OwnConnectorTestRequest.builder()
+                .build();
+    }
+}

--- a/src/test/java/org/connector/e2etestservice/controller/UiControllerTest.java
+++ b/src/test/java/org/connector/e2etestservice/controller/UiControllerTest.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 T-Systems International GmbH
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 T-Systems International GmbH
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/test/java/org/connector/e2etestservice/controller/UiControllerTest.java
+++ b/src/test/java/org/connector/e2etestservice/controller/UiControllerTest.java
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (c) 2023 T-Systems International GmbH
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.connector.e2etestservice.controller;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+public class UiControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+
+    @SneakyThrows
+    @Test
+    void testUiModelResponse() {
+
+        mvc.perform(MockMvcRequestBuilders
+                .get("/")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+        .andExpect(model().attributeExists("preconfiguredConnectorUrl"))
+        .andExpect(model().attributeExists("connectorApiKeyHeader"))
+        .andExpect(view().name("index"));
+
+    }
+}

--- a/src/test/java/org/connector/e2etestservice/service/ConnectorServiceTest.java
+++ b/src/test/java/org/connector/e2etestservice/service/ConnectorServiceTest.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 T-Systems International GmbH
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 T-Systems International GmbH
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/test/java/org/connector/e2etestservice/service/ConnectorServiceTest.java
+++ b/src/test/java/org/connector/e2etestservice/service/ConnectorServiceTest.java
@@ -20,7 +20,6 @@
 
 package org.connector.e2etestservice.service;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.connector.e2etestservice.facilitator.ConnectorFacilitator;
 import org.connector.e2etestservice.model.ConnectorTestRequest;
 import org.junit.jupiter.api.Test;
@@ -52,8 +51,8 @@ public class ConnectorServiceTest {
         ConnectorTestRequest providerConnector = getValidConnectorTestRequest();
 
         Mockito.when(dataOfferService.getCatalogRequestBody(providerConnector.getConnectorHost()+"/api/v1/dsp"))
-                .thenReturn((ObjectNode) any());
-        Mockito.when(connectorFacilitator.getContractOfferFromConnector(consumerConnector, (ObjectNode)any()))
+                .thenReturn(any());
+        Mockito.when(connectorFacilitator.getContractOfferFromConnector(consumerConnector, any()))
                 .thenReturn(getResponseEntityFromConnector());
 
         assertTrue(testConnectorService.testConnectorConnectivity(consumerConnector,
@@ -69,14 +68,15 @@ public class ConnectorServiceTest {
     }
 
     private ResponseEntity<String> getResponseEntityFromConnector() {
-        String connectorRes = "{\n" +
-                "    \"@id\": \"f9050d7a\",\n" +
-                "    \"@type\": \"dcat:Catalog\",\n" +
-                "    \"dcat:dataset\": {\n" +
-                "        \"@id\": \"sample\",\n" +
-                "        \"@type\": \"dcat:Dataset\"\n" +
-                "    }\n" +
-                "}";
+        String connectorRes = """
+                {
+                    "@id": "f9050d7a",
+                    "@type": "dcat:Catalog",
+                    "dcat:dataset": {
+                        "@id": "sample",
+                        "@type": "dcat:Dataset"
+                    }
+                }""";
 
         return new ResponseEntity<>(connectorRes, HttpStatus.OK);
     }

--- a/src/test/java/org/connector/e2etestservice/service/ConnectorServiceTest.java
+++ b/src/test/java/org/connector/e2etestservice/service/ConnectorServiceTest.java
@@ -1,0 +1,84 @@
+/********************************************************************************
+ * Copyright (c) 2023 T-Systems International GmbH
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.connector.e2etestservice.service;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.connector.e2etestservice.facilitator.ConnectorFacilitator;
+import org.connector.e2etestservice.model.ConnectorTestRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringBootTest
+public class ConnectorServiceTest {
+
+    @Autowired
+    private TestConnectorService testConnectorService;
+
+    @MockBean
+    private ConnectorFacilitator connectorFacilitator;
+
+    @MockBean
+    private DataOfferService dataOfferService;
+
+    @Test
+    public void connectorTestingMethod_Success() {
+        ConnectorTestRequest consumerConnector = getValidConnectorTestRequest();
+        ConnectorTestRequest providerConnector = getValidConnectorTestRequest();
+
+        Mockito.when(dataOfferService.getCatalogRequestBody(providerConnector.getConnectorHost()+"/api/v1/dsp"))
+                .thenReturn((ObjectNode) any());
+        Mockito.when(connectorFacilitator.getContractOfferFromConnector(consumerConnector, (ObjectNode)any()))
+                .thenReturn(getResponseEntityFromConnector());
+
+        assertTrue(testConnectorService.testConnectorConnectivity(consumerConnector,
+                providerConnector));
+    }
+
+    private ConnectorTestRequest getValidConnectorTestRequest() {
+        return ConnectorTestRequest.builder()
+                .apiKeyValue("api_key")
+                .apiKeyHeader("api_key_header")
+                .connectorHost("https://connector_host.com")
+                .build();
+    }
+
+    private ResponseEntity<String> getResponseEntityFromConnector() {
+        String connectorRes = "{\n" +
+                "    \"@id\": \"f9050d7a\",\n" +
+                "    \"@type\": \"dcat:Catalog\",\n" +
+                "    \"dcat:dataset\": {\n" +
+                "        \"@id\": \"sample\",\n" +
+                "        \"@type\": \"dcat:Dataset\"\n" +
+                "    }\n" +
+                "}";
+
+        return new ResponseEntity<>(connectorRes, HttpStatus.OK);
+    }
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -26,6 +26,9 @@ default.edc.hostname=https://testedc.com
 default.edc.apiKeyHeader=X-Api-Key
 default.edc.apiKey=testedcapikey
 
+# Sample Asset Name
+sample.asset.name=sampleAssetName
+
 ## EDC API path
 edc.ids.path=/api/v1/ids/data
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 #################################################################################
-# Copyright (c) 2023 T-Systems International GmbH
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023,2024 T-Systems International GmbH
+# Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -28,6 +28,7 @@ default.edc.apiKey=testedcapikey
 
 # Sample Asset Name
 sample.asset.name=sampleAssetName
+sample.asset.type=data.core.sample
 
 ## EDC API path
 edc.ids.path=/api/v1/ids/data


### PR DESCRIPTION
## Description

### Fixed
- Preconfigured connector URL '/' issue
- Dynamic asset name generation issue

### Added
- Unit tests for Controller and service

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
