### PR TITLE
fix: Vulnerability issue fix for base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+### Fixed
+- Fixed vulnerability issue in the base image
 
 ## [1.0.10] - 2024-02-12
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /tmp
 
 RUN mvn clean install -Dmaven.test.skip=true
 
-FROM eclipse-temurin:17.0.9_9-jdk-alpine
+FROM eclipse-temurin:17.0.10_7-jdk-jammy
 
 ENV TEMP=/tmp
 COPY --from=build $TEMP/target/*.jar /app/app.jar

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Currently, authentication is not supported for this service
 
 # Container images
 
-This application provides container images for demonstration purposes. The base image used, to build this demo application image is eclipse-temurin:17-jdk-alpine
+This application provides container images for demonstration purposes. The base image used, to build this demo application image is eclipse-temurin:17.0.10_7-jdk-jammy
 
 ## Notice for Docker image
 
@@ -57,7 +57,7 @@ __Data Exchange Test Service__
 
 **Used base image**
 
-- 17-jdk-alpine(https://hub.docker.com/layers/library/eclipse-temurin/17.0.6_10-jdk-alpine/images/sha256-c093675e143dc8023fb218c144e06491154491a7965d0664a93f99ada5259ec7?context=explore)
+- [eclipse-temurin:17.0.10_7-jdk-jammy](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin


### PR DESCRIPTION
- There is a vulnerability [CVE-2023-52425](https://avd.aquasec.com/nvd/cve-2023-52425) in base image in Dockerfile (eclipse-temurin:17.0.9_9-jdk-alpine)
- In order to fix this we have upgraded the image with eclipse-temurin:17.0.10_7-jdk-jammy