### PR TITLE
chore: Image version upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+- Base image upgraded due to vulenrabilites
 
 ## [1.0.10] - 2024-02-12
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /tmp
 
 RUN mvn clean install -Dmaven.test.skip=true
 
-FROM eclipse-temurin:17.0.9_9-jdk-alpine
+FROM eclipse-temurin:17.0.10_7-jdk-alpine
 
 ENV TEMP=/tmp
 COPY --from=build $TEMP/target/*.jar /app/app.jar


### PR DESCRIPTION
- As the current version of eclipse-temurin has vulnerability. So this PR consist of upgrade of base image to eclipse-temurin:17.0.10_7-jdk-alpine to fix the issue.